### PR TITLE
Replace setup-ruby action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "2.7.x"
+      - uses: ruby/setup-ruby@v1
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/cron:rotate_branding.yml
+++ b/.github/workflows/cron:rotate_branding.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: "2.7.x"
+      - uses: ruby/setup-ruby@v1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The action `actions/setup-ruby` is not maintained anymore and has been archived.

Its successor is `ruby/setup-ruby`, which automatically uses the ruby version specified in `.ruby-version`.