### PR TITLE
Remove deprecation warning when invoking image with block

### DIFF
--- a/lib/brand_rotator/image.rb
+++ b/lib/brand_rotator/image.rb
@@ -26,17 +26,15 @@ module BrandRotator
       end
 
       def open_svg_as_png(svg_path, width: nil)
-        image_array = Magick::Image.read(svg_path) {
-          self.format = "SVG"
-          self.background_color = "transparent"
-        }
+        image_array = Magick::Image.read(svg_path) do |img|
+          img.format = "SVG"
+          img.background_color = "transparent"
+        end
         image = image_array.first
 
         image.resize_to_fit!(width) unless width.nil?
 
-        image.to_blob {
-          self.format = "PNG"
-        }
+        image.to_blob { |img| img.format = "PNG" }
       end
     end
   end


### PR DESCRIPTION
Starting in version 4.2.3 [1], rmagick added a deprecation warning: `passing a block without an image argument is deprecated`. Version 5 removes the binding of the block to the image entirely [2].

Update our code to remove the deprecation and prepare for v5 upgrade.

[1]
https://github.com/rmagick/rmagick/compare/RMagick_4-2-2...RMagick_4-2-3

[2] https://github-redirect.dependabot.com/rmagick/rmagick/issues/1362